### PR TITLE
stupidly fast but stupid json marshaling

### DIFF
--- a/result.go
+++ b/result.go
@@ -1,5 +1,10 @@
 package geominder
 
+import (
+	"strconv"
+	"sync"
+)
+
 // LookupResult is a minimal set of location information that is queried for and
 // returned from our lookups.
 type LookupResult struct {
@@ -32,4 +37,83 @@ type location struct {
 	// The time zone associated with location, as specified by the IANA
 	// Time Zone Database, e.g., “America/New_York”.
 	// Timezone string `maxminddb:"time_zone"`
+}
+
+// FastJSON is an faster alternative to calling json.Marshal for a LookupResult.
+//
+// Yes, if you look at the code you will likely be horrified. Everything is hard
+// coded, so if the format for the LookupResult struct is modified, this will
+// have to be edited by hand again. So, why?
+//
+// json.Marshal is already very fast for a small struct like this. In fact,
+// using the popular code generation tools ffjson and easyjson, I was unable to
+// get them to be significantly more performant for this data struct, and in
+// most cases they were actualy slower (lesson: always measure!).
+//
+// However, by doing this hand-made "artisanal" encode, the end result is about
+// 2.5x faster than json/ffjson/easyjson.
+//
+// Note that implementing MarshalJSON with this does not get the same results,
+// since you still lose speed to the inital reflection on interface{} (quite a
+// bit more than I would have expected!).
+//
+// You probably don't need this. I may end up deleting it for maintainability.
+// However, if you are really trying to screaming fast speed, and every nanosec
+// is critical, it could be useful.
+func (lr *LookupResult) FastJSON() []byte {
+	b := make([]byte, 0, 128) // 106 is largest test case
+	b = append(b, `{"country":{"iso_code":"`...)
+	b = append(b, lr.Country.ISOCode...)
+	b = append(b, `"},"location":{"latitude":`...)
+	b = strconv.AppendFloat(b, lr.Location.Latitude, 'f', -1, 64)
+	b = append(b, `,"longitude":`...)
+	b = strconv.AppendFloat(b, lr.Location.Longitude, 'f', -1, 64)
+	b = append(b, `,"accuracy_radius":`...)
+	b = strconv.AppendInt(b, int64(lr.Location.Accuracy), 10)
+	b = append(b, `}}`...)
+	return b
+}
+
+// FasterJSON is like FastJSON but backed by an internal sync.Pool to handle
+// allocation of byte slices. If FastJSON scared you, then this will scar you.
+//
+// This version will return a pointer to the byteslice instead. When you are
+// done with the data, you can return the backing array to the pool by sending
+// that pointer back to PoolReturn(). BE SURE YOU ARE ACTUALLY DONE WITH IT.
+//
+// By utilizing that methodology, you can have zero memory allocations overall.
+//
+// However, this is not recommended unless you *really* need it, since you are
+// entering the world of needing to be obsessive about your object lifetimes to
+// avoid data race scenarios. Please be very careful and audit and measure your
+// code.
+//
+// TODO: possibly delete this monstrosity once we stabilize API.
+func (lr *LookupResult) FasterJSON() *[]byte {
+	b := dbFastJSONResultsPool.Get().(*[]byte)
+	(*b) = (*b)[:0] // reset slice to enable re-use from pool
+	(*b) = append((*b), `{"country":{"iso_code":"`...)
+	(*b) = append((*b), lr.Country.ISOCode...)
+	(*b) = append((*b), `"},"location":{"latitude":`...)
+	(*b) = strconv.AppendFloat((*b), lr.Location.Latitude, 'f', -1, 64)
+	(*b) = append((*b), `,"longitude":`...)
+	(*b) = strconv.AppendFloat((*b), lr.Location.Longitude, 'f', -1, 64)
+	(*b) = append((*b), `,"accuracy_radius":`...)
+	(*b) = strconv.AppendInt((*b), int64(lr.Location.Accuracy), 10)
+	(*b) = append((*b), `}}`...)
+	return b
+}
+
+var dbFastJSONResultsPool = sync.Pool{
+	New: func() interface{} {
+		bs := make([]byte, 0, 128)
+		return &bs
+	},
+}
+
+// PoolReturn returns a byteslice to the backing pool for potential re-use.PoolReturn
+//
+// Be sure you are done with it!
+func (lr *LookupResult) PoolReturn(b *[]byte) {
+	dbFastJSONResultsPool.Put(b)
 }

--- a/result_test.go
+++ b/result_test.go
@@ -1,0 +1,52 @@
+package geominder
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+var jsonTestCase = testCases[2].expected
+
+func TestFastJSON(t *testing.T) {
+	for _, tc := range testCases {
+		res := tc.expected
+		expected, _ := json.Marshal(res)
+		actual := res.FastJSON()
+		if !bytes.Equal(expected, actual) {
+			t.Errorf("JSON mismatch! want %s, got %s", expected, actual)
+		}
+	}
+}
+
+func TestFasterJSON(t *testing.T) {
+	for _, tc := range testCases {
+		res := tc.expected
+		expected, _ := json.Marshal(res)
+		actual := *res.FasterJSON()
+		if !bytes.Equal(expected, actual) {
+			t.Errorf("JSON mismatch! want %s, got %s", expected, actual)
+		}
+	}
+}
+
+func BenchmarkDBResultJSON(b *testing.B) {
+	res := testCases[2].expected
+
+	b.Run("Marshal", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			json.Marshal(res)
+		}
+	})
+	b.Run("FastJSON", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			res.FastJSON()
+		}
+	})
+	b.Run("FasterJSON", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			bs := res.FasterJSON()
+			res.PoolReturn(bs)
+		}
+	})
+}


### PR DESCRIPTION
Strong emphasis on the "stupid".

It's likely I won't end up using these since the complexity of maintaining is possibly not worth the tradeoff, but for now I want to add them to the core library API, and later I will benchmark it's effect on the overall HTTP response performance and see if it's worth adopting either.

Interestingly, neither `ffjson` nor `easyjson` was able to really outperform the built in `json.Marshal` for such a simple struct.

This poorly advised hack, on the other hand, does get 2.5x faster results, and allows for zero-allocation if desired, but at the cost of one's sanity.

```
$ go test -bench=JSON -benchmem
goos: darwin
goarch: amd64
pkg: github.com/mroth/geominder
BenchmarkDBResultJSON/Marshal-16         	 850 ns/op	     160 B/op	       2 allocs/op
BenchmarkDBResultJSON/FastJSON-16        	 299 ns/op	     128 B/op	       1 allocs/op
BenchmarkDBResultJSON/FasterJSON-16      	 286 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/mroth/geominder	6.128s
```