### PR TITLE
investigate switch to bigcache

### DIFF
--- a/cmd/geominder/main.go
+++ b/cmd/geominder/main.go
@@ -12,6 +12,7 @@ import (
 
 func main() {
 	var dbPath = flag.String("db", "data/GeoLite2-City.mmdb", "Path of MaxMind GeoIP2/GeoLite2 database")
+	var cacheSize = flag.Uint("cache", geominder.DefaultMaxCacheSize, "Max memory used for caching responses in MB")
 	var originPolicy = flag.String("origin", geominder.DefaultOriginPolicy, `Value for 'Access-Control-Allow-Origin' header, set to "" to disable.`)
 	var port = flag.Int("port", 9000, "Port to listen for connections on")
 	var threads = flag.Int("threads", runtime.NumCPU(), "Number of threads to use, otherwise number of detected cores")
@@ -26,7 +27,7 @@ func main() {
 	}
 	defer db.Close()
 
-	lh := geominder.NewHTTPHandler(db).SetOriginPolicy(*originPolicy)
+	lh := geominder.NewHTTPHandler(db).SetOriginPolicy(*originPolicy).EnableCacheOfSize(*cacheSize)
 
 	// Logging of connections is disabled
 	// Logging of connections is enabled, this may severely impact performance under extremely high utilization


### PR DESCRIPTION
Investigation of bigcache performance, which should theory speed concurrent reads. I also like that it has a configurable hard max size for cache which could prevent OOM killer in certain edge case scenarios.

Initial results look fairly good:

```
benchmark                               old ns/op     new ns/op     delta
BenchmarkHTTPRequest-16                 3460          3424          -1.04%
BenchmarkHTTPRequestWithCache-16        611           597           -2.29%
BenchmarkHTTPRequestPar-16              459           442           -3.70%
BenchmarkHTTPRequestParWithCache-16     176           151           -14.20%

benchmark                               old allocs     new allocs     delta
BenchmarkHTTPRequest-16                 9              9              +0.00%
BenchmarkHTTPRequestWithCache-16        5              7              +40.00%
BenchmarkHTTPRequestPar-16              9              9              +0.00%
BenchmarkHTTPRequestParWithCache-16     5              7              +40.00%

benchmark                               old bytes     new bytes     delta
BenchmarkHTTPRequest-16                 840           839           -0.12%
BenchmarkHTTPRequestWithCache-16        661           789           +19.36%
BenchmarkHTTPRequestPar-16              911           1017          +11.64%
BenchmarkHTTPRequestParWithCache-16     790           982           +24.30%
```

This does add 2 memory allocations to the cache-hit case (which is consistent with the benchmarks in bigcache's readme compared to a map based solution), but we see an overall 14% improvement in throughput in the parallel test, which seems good!

However things get more interesting if I increase the benchtime significantly, testing here with it bumped up to `1m`:

```
benchmark                               old ns/op     new ns/op     delta
BenchmarkHTTPRequest-16                 3457          3323          -3.88%
BenchmarkHTTPRequestWithCache-16        722           802           +11.08%
BenchmarkHTTPRequestPar-16              627           684           +9.09%
BenchmarkHTTPRequestParWithCache-16     896           973           +8.59%

benchmark                               old allocs     new allocs     delta
BenchmarkHTTPRequest-16                 9              9              +0.00%
BenchmarkHTTPRequestWithCache-16        5              7              +40.00%
BenchmarkHTTPRequestPar-16              9              9              +0.00%
BenchmarkHTTPRequestParWithCache-16     5              7              +40.00%

benchmark                               old bytes     new bytes     delta
BenchmarkHTTPRequest-16                 854           854           +0.00%
BenchmarkHTTPRequestWithCache-16        721           849           +17.75%
BenchmarkHTTPRequestPar-16              899           903           +0.44%
BenchmarkHTTPRequestParWithCache-16     721           853           +18.31%
```

Interesting to note that in *both* these cases (go-cache and bigcache), the overall BenchmarkParallel performance on this machine (8-core Xeon) becomes significantly worse... I suspected what may be happening is the impact of garbage collection, however the cached version being disproportionally effected is confusing.